### PR TITLE
Version bumps and add GOPROXY make configs -- remove straggling pinata commands

### DIFF
--- a/common.config.mk
+++ b/common.config.mk
@@ -12,13 +12,28 @@ VERSION=0.1.0-SNAPSHOT
 
 # The makefiles use docker images to build artifacts in this project.  These
 # variables configure the images used for builds.
-BUILDENV_TAG=0.0.40
+BUILDENV_TAG=0.0.41
 
 # These variables control the version numbers for parts of the LEIA platform
 # and should be kept up-to-date to leverage the latest platform features.
-SUBSTRATE_VERSION=2.159.0-plt131test-SNAPSHOT-9175e96
+SUBSTRATE_VERSION=2.160.0-fabric2-SNAPSHOT-4bdb08c
 SHIROCLIENT_VERSION=2.159.0-fabric2-SNAPSHOT
 SHIROTESTER_VERSION=2.159.0-fabric2-SNAPSHOT
 CHAINCODE_VERSION=${SUBSTRATE_VERSION}
 NETWORK_BUILDER_VERSION=2.159.0-fabric2-SNAPSHOT
 MARTIN_VERSION=0.1.0-SNAPSHOT
+
+# A golang module proxy server can greatly help speed up docker builds but the
+# official proxy at https://proxy.golang.org only works for public modules.
+# When your application needs private go module dependencies consider running a
+# local athens-proxy server with an ssh/http configuration which can access
+# private source repositories, otherwise set GOPRIVATE (or GONOPROXY and
+# GONOSUMDB) if private modules are needed.  Though be aware that GOPRIVATE
+# requires credentials (e.g. for github ssh) be available during builds which
+# complicates things considerably.
+# 		https://docs.gomods.io/
+# 		https://golang.org/ref/mod#private-modules
+GOPROXY ?= https://proxy.golang.org
+GOPRIVATE ?=
+GONOPROXY ?= ${GOPRIVATE}
+GONOSUMDB ?= ${GOPRIVATE}

--- a/common.go.mk
+++ b/common.go.mk
@@ -22,6 +22,8 @@ STATIC_IMAGE_DUMMY=$(call IMAGE_DUMMY,${STATIC_IMAGE}/${VERSION})
 
 GO_SOURCE_FILES=$(shell find ${PROJECT_REL_DIR} -name '*.go' | grep -v '/vendor/')
 
+GO_MOD_ENV=-e "GOPROXY=${GOPROXY}" -e "GOPRIVATE=${GOPRIVATE}" -e "GONOPROXY=${GONOPROXY}" -e "GONOSUMDB=${GONOSUMDB}"
+
 GO_PKG_DUMMY=${PROJECT_REL_DIR}/$(call DUMMY_TARGET,pkg,${GO_PKG_VOLUME})
 GO_PKG_VOLUME_DUMMY=${PROJECT_REL_DIR}/$(call DUMMY_TARGET,volume,${GO_PKG_VOLUME})
 
@@ -60,9 +62,9 @@ ${STATIC_IMAGE_DUMMY}: ${GO_SOURCE_FILES} Makefile ${PROJECT_REL_DIR}/common.mk 
 	${MKDIR_P} $(dir $@)
 	${TIME_P} ${DOCKER_RUN} \
 		${DOCKER_IN_DOCKER_MOUNT} \
-		$(shell pinata-ssh-mount) \
 		${GO_PKG_MOUNT} \
 		${SUBSTRATEHCP_MOUNT} \
+		${GO_MOD_ENV} \
 		-v ${DOCKER_PROJECT_DIR}:${BUILD_IMAGE_PROJECT_DIR} \
 		-e "CGO_LDFLAGS_ALLOW=-Wl,--no-as-needed" \
 		-e "BIN=${BIN}" \
@@ -75,9 +77,9 @@ ${STATIC_IMAGE_DUMMY}: ${GO_SOURCE_FILES} Makefile ${PROJECT_REL_DIR}/common.mk 
 .PHONY: test
 test: ${GO_PKG_DUMMY}
 	${TIME_P} ${DOCKER_RUN} \
-		$(shell pinata-ssh-mount) \
 		${GO_PKG_MOUNT} \
 		${SUBSTRATEHCP_MOUNT} \
+		${GO_MOD_ENV} \
 		-v ${DOCKER_PROJECT_DIR}:${BUILD_IMAGE_PROJECT_DIR} \
 		-w  ${BUILD_WORKDIR} \
 		${BUILD_IMAGE} test


### PR DESCRIPTION
There's no real need to actually start an athens-proxy server and it
would bloat the makefile.  It could just be on the docs site.