### PR TITLE
Set default make goal explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GO_SERVICE_PACKAGES=./oracleserv/... ./phylum/...
 GO_API_PACKAGES=./api/...
 GO_PACKAGES=${GO_SERVICE_PACKAGES} ${GO_API_PACKAGES}
 
+.DEFAULT_GOAL := all
 .PHONY: default
 default: all
 


### PR DESCRIPTION
Default is otherwise 'first normal target in file' which is a bad fit
for the complexities of our make setup. Particularly with includes.