### PR TITLE
Add explorer to sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,26 @@ ifdef LOCAL_WORKSPACE_FOLDER # if in codespace
 endif
 
 .PHONY: down
-down: mem-down
+down: mem-down explorer-down
+
+.PHONY: explorer
+explorer: explorer-up
+
+.PHONY: explorer-up
+explorer-up:
+	cd ${PROJECT_REL_DIR}/explorer && make up
+
+.PHONY: explorer-down
+explorer-down:
+	cd ${PROJECT_REL_DIR}/explorer && make down
+
+.PHONY: explorer-clean
+explorer-clean:
+	cd ${PROJECT_REL_DIR}/explorer && make down-clean
+
+.PHONY: explorer-watch
+explorer-watch:
+	cd ${PROJECT_REL_DIR}/explorer && make watch
 
 .PHONY: mem-up
 mem-up: all mem-down

--- a/explorer/.env
+++ b/explorer/.env
@@ -1,0 +1,4 @@
+PORT=8090
+EXPLORER_CONFIG_FILE_PATH=./config.json
+EXPLORER_PROFILE_DIR_PATH=./connection-profile
+FABRIC_CRYPTO_PATH=./organizations

--- a/explorer/.env
+++ b/explorer/.env
@@ -1,4 +1,4 @@
 PORT=8090
 EXPLORER_CONFIG_FILE_PATH=./config.json
 EXPLORER_PROFILE_DIR_PATH=./connection-profile
-FABRIC_CRYPTO_PATH=./organizations
+FABRIC_CRYPTO_PATH=../fabric/crypto-config

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -13,12 +13,13 @@ watch: up
 	docker logs explorer.luther.systems
 
 .PHONY: up-clean
-up-clean: down-clean
+up-clean: #this needs to be recipe, not a prereq, for ordering purposes
+	make down-clean
 	make up
 
 .PHONY: down
 down:
-	- docker-compose down
+	docker-compose down
 
 .PHONY: down-clean
 down-clean:

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -7,11 +7,6 @@ up: down
 	./check_for_peers.sh
 	docker-compose up -d
 
-.PHONY: watch
-watch: up
-	docker logs explorerdb.luther.systems
-	docker logs explorer.luther.systems
-
 .PHONY: up-clean
 up-clean: #this needs to be recipe, not a prereq, for ordering purposes
 	make down-clean

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -14,8 +14,7 @@ watch: up
 
 .PHONY: up-clean
 up-clean: down-clean
-	./check_for_peers.sh
-	docker-compose up -d
+	make up
 
 .PHONY: down
 down:

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -1,0 +1,24 @@
+# Copyright © 2022 Luther Systems, Ltd. All rights reserved.
+
+.DEFAULT_GOAL := up-clean
+
+.PHONY: up
+up: down
+	docker-compose up -d
+
+.PHONY: watch
+watch: up
+	docker logs explorerdb.luther.systems
+	docker logs explorer.luther.systems
+
+.PHONY: up-clean
+up-clean: down-clean
+	docker-compose up -d
+
+.PHONY: down
+down:
+	docker-compose down
+
+.PHONY: down-clean
+down-clean:
+	docker-compose down -v

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -4,6 +4,7 @@
 
 .PHONY: up
 up: down
+	./check_for_peers.sh
 	docker-compose up -d
 
 .PHONY: watch
@@ -13,11 +14,12 @@ watch: up
 
 .PHONY: up-clean
 up-clean: down-clean
+	./check_for_peers.sh
 	docker-compose up -d
 
 .PHONY: down
 down:
-	docker-compose down
+	- docker-compose down
 
 .PHONY: down-clean
 down-clean:

--- a/explorer/check_for_peers.sh
+++ b/explorer/check_for_peers.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+PEERS_EXTANT=$(docker ps -a --format '{{.Names}}' -f "name=^peer[0-9]+\.org[0-9]+")
+if [ -z "$PEERS_EXTANT" ]; then
+    echo "Explorer cannot run without network to connect to."
+    exit 1
+fi
+exit 0

--- a/explorer/check_for_peers.sh
+++ b/explorer/check_for_peers.sh
@@ -2,7 +2,7 @@
 
 PEERS_EXTANT=$(docker ps -a --format '{{.Names}}' -f "name=^peer[0-9]+\.org[0-9]+")
 if [ -z "$PEERS_EXTANT" ]; then
-    echo "Explorer cannot run without network to connect to."
+    echo "Explorer cannot run without network to connect to. Try `make fabric-up`."
     exit 1
 fi
 exit 0

--- a/explorer/check_for_peers.sh
+++ b/explorer/check_for_peers.sh
@@ -2,7 +2,7 @@
 
 PEERS_EXTANT=$(docker ps -a --format '{{.Names}}' -f "name=^peer[0-9]+\.org[0-9]+")
 if [ -z "$PEERS_EXTANT" ]; then
-    echo "Explorer cannot run without network to connect to. Try `make fabric-up`."
+    echo "Explorer cannot run without network to connect to. Try 'make fabric'."
     exit 1
 fi
 exit 0

--- a/explorer/config.json
+++ b/explorer/config.json
@@ -1,0 +1,9 @@
+{
+	"network-configs": {
+		"sandbox-test-network": {
+			"name": "Sandbox Test Network",
+			"profile": "./connection-profile/test-network.json"
+		}
+	},
+	"license": "Apache-2.0"
+}

--- a/explorer/connection-profile/test-network.json
+++ b/explorer/connection-profile/test-network.json
@@ -1,0 +1,48 @@
+{
+	"name": "sandbox-test-network",
+	"version": "1.0.0",
+	"client": {
+		"tlsEnable": false,
+		"adminCredential": {
+			"id": "admin",
+			"password": "adminpw"
+		},
+		"enableAuthentication": true,
+		"organization": "Org1MSP",
+		"connection": {
+			"timeout": {
+				"peer": {
+					"endorser": "300"
+				},
+				"orderer": "300"
+			}
+		}
+	},
+	"channels": {
+		"luther": {
+			"peers": {
+				"peer0.org1.luther.systems": {}
+			}
+		}
+	},
+	"organizations": {
+		"Org1MSP": {
+			"mspid": "Org1MSP",
+			"adminPrivateKey": {
+				"path": "/tmp/crypto/peerOrganizations/org1.luther.systems/users/User1@org1.luther.systems/msp/keystore/priv_sk"
+			},
+			"peers": ["peer0.org1.luther.systems"],
+			"signedCert": {
+				"path": "/tmp/crypto/peerOrganizations/org1.luther.systems/users/User1@org1.luther.systems/msp/signcerts/User1@org1.luther.systems-cert.pem"
+			}
+		}
+	},
+	"peers": {
+		"peer0.org1.luther.systems": {
+			"tlsCACerts": {
+				"path": "/tmp/crypto/peerOrganizations/org1.luther.systems/peers/peer0.org1.luther.systems/tls/ca.crt"
+			},
+			"url": "grpcs://peer0.org1.luther.systems:7051"
+		}
+	}
+}

--- a/explorer/docker-compose.yaml
+++ b/explorer/docker-compose.yaml
@@ -1,0 +1,59 @@
+
+# SPDX-License-Identifier: Apache-2.0
+version: '2.1'
+
+volumes:
+  pgdata:
+  walletstore:
+
+networks:
+  luther.systems:
+    name: fnb_byfn
+
+services:
+
+  explorerdb.luther.systems:
+    image: luthersystems/blockexplorer-db:latest
+    container_name: explorerdb.luther.systems
+    hostname: explorerdb.luther.systems
+    environment:
+      - DATABASE_DATABASE=fabricexplorer
+      - DATABASE_USERNAME=hppoc
+      - DATABASE_PASSWORD=password
+    healthcheck:
+      test: "pg_isready -h localhost -p 5432 -q -U postgres"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - luther.systems
+
+  explorer.luther.systems:
+    image: luthersystems/blockexplorer:latest
+    container_name: explorer.luther.systems
+    hostname: explorer.luther.systems
+    environment:
+      - DATABASE_HOST=explorerdb.luther.systems
+      - DATABASE_DATABASE=fabricexplorer
+      - DATABASE_USERNAME=hppoc
+      - DATABASE_PASSWD=password
+      - LOG_LEVEL_APP=info
+      - LOG_LEVEL_DB=info
+      - LOG_LEVEL_CONSOLE=debug
+      - LOG_CONSOLE_STDOUT=true
+      - DISCOVERY_AS_LOCALHOST=false
+      - PORT=${PORT:-8080}
+    volumes:
+      - ${EXPLORER_CONFIG_FILE_PATH}:/opt/explorer/app/platform/fabric/config.json
+      - ${EXPLORER_PROFILE_DIR_PATH}:/opt/explorer/app/platform/fabric/connection-profile
+      - ${FABRIC_CRYPTO_PATH}:/tmp/crypto
+      - walletstore:/opt/explorer/wallet
+    ports:
+      - ${PORT:-8080}:${PORT:-8080}
+    depends_on:
+      explorerdb.luther.systems:
+        condition: service_healthy
+    networks:
+      - luther.systems

--- a/explorer/docker-compose.yaml
+++ b/explorer/docker-compose.yaml
@@ -8,7 +8,8 @@ volumes:
 
 networks:
   luther.systems:
-    name: fnb_byfn
+    external:
+      name: fnb_byfn
 
 services:
 

--- a/fabric/base/docker-compose-base.yaml
+++ b/fabric/base/docker-compose-base.yaml
@@ -21,7 +21,7 @@ services:
       - ORDERER_GENERAL_TLS_PRIVATEKEY=/var/hyperledger/orderer/tls/server.key
       - ORDERER_GENERAL_TLS_CERTIFICATE=/var/hyperledger/orderer/tls/server.crt
       - ORDERER_GENERAL_TLS_ROOTCAS=[/var/hyperledger/orderer/tls/ca.crt]
-      - ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED=true
+      - ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED=false
       # NOTE:  Raft TLS server & client for a node will use the same cert/key
       # -- This matches the configtx.yaml Orderer.EtcdRaft.Concenters
       # configuration.

--- a/fabric/base/peer-base.yaml
+++ b/fabric/base/peer-base.yaml
@@ -19,7 +19,7 @@ services:
       - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
       - CORE_CHAINCODE_BUILDER=$IMAGE_NS/fabric-ccenv:$IMAGE_TAG
       - CORE_CHAINCODE_STARTUPTIMEOUT=500s
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=false
       - DOCKER_PROJECT_DIR
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
     command: peer node start

--- a/fabric/common.fabric.mk
+++ b/fabric/common.fabric.mk
@@ -85,19 +85,6 @@ default: ${CC_PATH}
 images: ${FABRIC_IMAGE_TARGETS} ${SHIROCLIENT_TARGET} ${NETWORK_BUILDER_TARGET}
 	@
 
-.PHONY: clean
-clean: fabric-clean
-
-.PHONY: fabric-clean
-fabric-clean:
-	rm -rf build
-
-.PHONY: pristine
-pristine: clean clean-generated
-
-.PHONY: clean-generated
-clean-generated: fabric-clean
-
 .PHONY: install
 all: install
 install: ${NETWORK_BUILDER_TARGET} ${CC_PATH}

--- a/fabric/docker-compose-cli.yaml
+++ b/fabric/docker-compose-cli.yaml
@@ -53,7 +53,7 @@ services:
       - CORE_PEER_TLS_KEY_FILE=/crypto-config/peerOrganizations/org1.luther.systems/peers/peer0.org1.luther.systems/tls/server.key
       - CORE_PEER_TLS_ROOTCERT_FILE=/crypto-config/peerOrganizations/org1.luther.systems/peers/peer0.org1.luther.systems/tls/ca.crt
       - CORE_PEER_MSPCONFIGPATH=/crypto-config/peerOrganizations/org1.luther.systems/users/Admin@org1.luther.systems/msp
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=false
       - CORE_PEER_TLS_CLIENTCERT_FILE=/crypto-config/peerOrganizations/org1.luther.systems/peers/peer0.org1.luther.systems/tls/server.crt
       - CORE_PEER_TLS_CLIENTKEY_FILE=/crypto-config/peerOrganizations/org1.luther.systems/peers/peer0.org1.luther.systems/tls/server.key
       - DOCKER_PROJECT_DIR

--- a/fabric/scripts/luther_utils.sh
+++ b/fabric/scripts/luther_utils.sh
@@ -67,7 +67,7 @@ setGlobals() {
     export CORE_PEER_TLS_ROOTCERT_FILE="$(peerRootCert "$PEER" "$ORG")"
     export CORE_PEER_TLS_CLIENTCERT_FILE="${CORE_PEER_TLS_CERT_FILE}"
     export CORE_PEER_TLS_CLIENTKEY_FILE="${CORE_PEER_TLS_KEY_FILE}"
-    export CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+    export CORE_PEER_TLS_CLIENTAUTHREQUIRED=false
 
     env |grep CORE >&2
 }


### PR DESCRIPTION
Explorer sits in sandbox subdir and can be run with `docker-compose` or with `make` in that subdir. I haven't gotten a version that can be run from the root directory with `make`; that is a separate branch for now.