### PR TITLE
Top-level explorer make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,27 @@ else
 	$(error Target 'up' is for a full network, not supported in codespaces)
 endif
 
+.PHONY: explorer
+explorer: explorer-up
+
+.PHONY: explorer-up
+explorer-up:
+	cd ${PROJECT_REL_DIR}/explorer && make up
+
 .PHONY: down
-down: mem-down
+down: mem-down explorer-down
 ifndef LOCAL_WORKSPACE_FOLDER # if not in codespace
 	make full-down
 endif
 	@
+
+.PHONY: explorer-down
+explorer-down:
+	cd ${PROJECT_REL_DIR}/explorer && make down
+
+.PHONY: explorer-clean
+explorer-clean:
+	cd ${PROJECT_REL_DIR}/explorer && make down-clean
 
 .PHONY: mem-up
 mem-up: all mem-down

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: up
 up: down
-	bash ./check_for_peers.sh
+	./check_for_peers.sh
 	docker-compose up -d
 
 .PHONY: watch
@@ -18,7 +18,7 @@ up-clean: down-clean
 
 .PHONY: down
 down:
-	docker-compose down
+	- docker-compose down
 
 .PHONY: down-clean
 down-clean:

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: up
 up: down
-	./check_for_peers.sh
+	bash ./check_for_peers.sh
 	docker-compose up -d
 
 .PHONY: watch
@@ -14,7 +14,7 @@ watch: up
 
 .PHONY: up-clean
 up-clean: down-clean
-	./check_for_peers.sh
+	bash ./check_for_peers.sh
 	docker-compose up -d
 
 .PHONY: down

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -13,12 +13,13 @@ watch: up
 	docker logs explorer.luther.systems
 
 .PHONY: up-clean
-up-clean: down-clean
+up-clean: #needs to be recipe for ordering
+	make down-clean
 	make up
 
 .PHONY: down
 down:
-	- docker-compose down
+	docker-compose down
 
 .PHONY: down-clean
 down-clean:

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -1,21 +1,21 @@
 # Copyright © 2022 Luther Systems, Ltd. All right reserved.
 
-PROJECT_REL_DIR=..
+PROJECT_REL_DIR ?= ..
 
 .DEFAULT_GOAL := up-clean
 
 .PHONY: up
 up: down
-	docker-compose up -d
+	${PROJECT_REL_DIR}/explorer/create_explorer.sh
 
 .PHONY: watch
 watch: up
 	docker logs explorerdb.luther.systems
-	docker logs --follow explorer.luther.systems
+	docker logs explorer.luther.systems
 
 .PHONY: up-clean
 up-clean: down-clean
-	docker-compose up -d
+	${PROJECT_REL_DIR}/explorer/create_explorer.sh
 
 .PHONY: down
 down:

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -6,7 +6,8 @@ PROJECT_REL_DIR ?= ..
 
 .PHONY: up
 up: down
-	${PROJECT_REL_DIR}/explorer/create_explorer.sh
+	${PROJECT_REL_DIR}/explorer/check_for_peers.sh
+	docker-compose up -d
 
 .PHONY: watch
 watch: up
@@ -15,7 +16,8 @@ watch: up
 
 .PHONY: up-clean
 up-clean: down-clean
-	${PROJECT_REL_DIR}/explorer/create_explorer.sh
+	${PROJECT_REL_DIR}/explorer/check_for_peers.sh
+	docker-compose up -d
 
 .PHONY: down
 down:

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -14,8 +14,7 @@ watch: up
 
 .PHONY: up-clean
 up-clean: down-clean
-	bash ./check_for_peers.sh
-	docker-compose up -d
+	make up
 
 .PHONY: down
 down:

--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -1,12 +1,10 @@
 # Copyright © 2022 Luther Systems, Ltd. All right reserved.
 
-PROJECT_REL_DIR ?= ..
-
 .DEFAULT_GOAL := up-clean
 
 .PHONY: up
 up: down
-	${PROJECT_REL_DIR}/explorer/check_for_peers.sh
+	./check_for_peers.sh
 	docker-compose up -d
 
 .PHONY: watch
@@ -16,7 +14,7 @@ watch: up
 
 .PHONY: up-clean
 up-clean: down-clean
-	${PROJECT_REL_DIR}/explorer/check_for_peers.sh
+	./check_for_peers.sh
 	docker-compose up -d
 
 .PHONY: down

--- a/explorer/check_for_peers.sh
+++ b/explorer/check_for_peers.sh
@@ -1,0 +1,8 @@
+#! bash
+
+PEERS_EXTANT=$(docker ps -a --format '{{.Names}}' -f "name=^peer[0-9]+\.org[0-9]+")
+if [ -z "$PEERS_EXTANT" ]; then
+    echo "Explorer cannot run without network to connect to."
+    exit 1
+fi
+exit 0

--- a/explorer/check_for_peers.sh
+++ b/explorer/check_for_peers.sh
@@ -2,7 +2,7 @@
 
 PEERS_EXTANT=$(docker ps -a --format '{{.Names}}' -f "name=^peer[0-9]+\.org[0-9]+")
 if [ -z "$PEERS_EXTANT" ]; then
-    echo "Explorer cannot run without network to connect to."
+    echo "Explorer cannot run without network to connect to. Try `make fabric-up`."
     exit 1
 fi
 exit 0

--- a/explorer/check_for_peers.sh
+++ b/explorer/check_for_peers.sh
@@ -1,4 +1,4 @@
-#! bash
+#!/usr/bin/env bash
 
 PEERS_EXTANT=$(docker ps -a --format '{{.Names}}' -f "name=^peer[0-9]+\.org[0-9]+")
 if [ -z "$PEERS_EXTANT" ]; then

--- a/explorer/docker-compose.yaml
+++ b/explorer/docker-compose.yaml
@@ -8,7 +8,8 @@ volumes:
 
 networks:
   luther.systems:
-    name: fnb_byfn
+    external:
+      name: fnb_byfn
 
 services:
 


### PR DESCRIPTION
Haven't found a satisfactory version of this - There's a configuration where it reboots the network every time the explorer is brought up or down, and another which generates cryptic errors:
```sh
cd ./explorer && make up
retrieving hyperledger/fabric-peer\:
invalid reference format
make[1]: *** [docker-pull/hyperledger/fabric-peer\:] Error 1
make: *** [explorer-up] Error 2
```
