### PR TITLE
Fix up bad full-network make targets from codespaces mem split

### DIFF
--- a/common.fullnetwork.mk
+++ b/common.fullnetwork.mk
@@ -6,7 +6,7 @@
 # not in the in-memory network. Not used within Codespaces.
 
 .PHONY: storage-up
-storage-up: storage-down
+storage-up:
 	cd fabric && $(MAKE) up install init
 
 .PHONY: storage-down
@@ -14,7 +14,7 @@ storage-down:
 	-cd fabric && $(MAKE) down
 
 .PHONY: service-up
-service-up: api oracle service-down
+service-up: api oracle storage-up
 	./${PROJECT}_compose.py local up -d
 
 .PHONY: service-down
@@ -22,14 +22,19 @@ service-down:
 	-./${PROJECT}_compose.py local down
 
 .PHONY: up
-up: full-down full-up
+up: _up-internal
+
+.PHONY: _up-internal
+_up-internal:
+	make full-down
+	make full-up
 
 .PHONY: full-up
 full-up: all storage-up service-up
 	@
 
 .PHONY: down
-up: full-down
+down: full-down
 
 .PHONY: full-down
 full-down: service-down storage-down

--- a/common.fullnetwork.mk
+++ b/common.fullnetwork.mk
@@ -6,7 +6,7 @@
 # not in the in-memory network. Not used within Codespaces.
 
 .PHONY: storage-up
-storage-up:
+storage-up: storage-down
 	cd fabric && $(MAKE) up install init
 
 .PHONY: storage-down
@@ -14,7 +14,7 @@ storage-down:
 	-cd fabric && $(MAKE) down
 
 .PHONY: service-up
-service-up: api oracle
+service-up: api oracle service-down
 	./${PROJECT}_compose.py local up -d
 
 .PHONY: service-down
@@ -25,7 +25,7 @@ service-down:
 up: full-down full-up
 
 .PHONY: full-up
-full-up: all service-down storage-down storage-up service-up
+full-up: all storage-up service-up
 	@
 
 .PHONY: down

--- a/common.fullnetwork.mk
+++ b/common.fullnetwork.mk
@@ -21,14 +21,6 @@ service-up: api oracle storage-up
 service-down:
 	-./${PROJECT}_compose.py local down
 
-.PHONY: up
-up: _up-internal
-
-.PHONY: _up-internal
-_up-internal:
-	make full-down
-	make full-up
-
 .PHONY: full-up
 full-up: all storage-up service-up
 	@

--- a/compose/mem.yaml
+++ b/compose/mem.yaml
@@ -18,4 +18,6 @@ services:
     networks:
     - byfn
 networks:
+  fnb_byfn:
+    external: true
   byfn:


### PR DESCRIPTION
Didn't catch them at the time, and left competing recipe definitions for the full-network targets. (As seen in the engineering demo.)