### PR TITLE
Datadog metrics from within phylum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .luther-license.yaml
+.env

--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,15 @@ endif
 down: mem-down explorer-down
 
 .PHONY: explorer
-explorer: explorer-up
+explorer: explorer-up-clean
 
 .PHONY: explorer-up
 explorer-up:
 	cd ${PROJECT_REL_DIR}/explorer && make up
+
+.PHONY: explorer-up-clean
+explorer-up-clean:
+	cd ${PROJECT_REL_DIR}/explorer && make up-clean
 
 .PHONY: explorer-down
 explorer-down:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,32 @@ make down
 
 Running `docker ps` again will show all the containers have been removed.
 
+### Run Blockchain Explorer
+
+To examine a graphical UI for the chaincodee transactions and blocks and look at
+the details of the work the sandbox network has done, build the Blockchain
+Explorer. With the full network running, run:
+
+```
+make explorer
+```
+
+This creates a web app which will be visible on `localhost:8090`. The default
+login credentials are username: `admin`, password `adminpw`. Bringing up the
+network should produce some transactions and blocks, and `make integration` will
+generate more activity, which can be viewed in the web app.
+
+If the `make` command fails, or if the Explorer runs but no new activity is
+detected, it has most likely failed to authenticate; run
+
+```
+make explorer-clean
+make explorer-up
+```
+
+To wipe out the pre-existing database and recreate it empty, then re-build the
+Explorer. This will reconnect it to the current network.
+
 ## Build in Codespaces
 
 Run `make` to build all the services:

--- a/compose/local.yaml
+++ b/compose/local.yaml
@@ -11,6 +11,9 @@ services:
     environment:
     - SANDBOX_ORACLE_EMULATE_CC=false
     - SANDBOX_ORACLE_GATEWAY_ENDPOINT=http://shiroclient_gw_phylum:8082
+    # include these in compose/.env
+    - DD_API_KEY=${DD_API_KEY}
+    - DD_APP_KEY=${DD_APP_KEY}
     networks:
     - fnb_byfn
 networks:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/luthersystems/sandbox
 go 1.16
 
 require (
+	github.com/DataDog/datadog-api-client-go v1.14.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/datadog-api-client-go v1.14.0 h1:7ZITahghFVmC32GZ7DFcoEPdajvkS7cPWYQ29WJR6ko=
+github.com/DataDog/datadog-api-client-go v1.14.0/go.mod h1:15sqwH81WH6nCgW+rWyHw6PdaBA3udYAOq0p5lntKcY=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -506,6 +508,7 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f h1:Qmd2pbz05z7z6lm0DrgQVVPuBm92jqujBKMHMOlOQEw=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -659,6 +662,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/phylum/phylum.go
+++ b/phylum/phylum.go
@@ -77,6 +77,22 @@ func isDatadogSetUp(ctx context.Context) bool {
 	return false
 }
 
+type datadogSetup struct {
+	Config *datadog.Configuration
+	Client *datadog.APIClient
+}
+
+var defaultDatadogSetup datadogSetup
+
+func createDatadogSetup(ctx context.Context, email string) {
+	if !isDatadogSetUp(ctx) {
+		ctx = addDataDogCtx(ctx)
+	}
+	defaultDatadogSetup.Config = datadog.NewdefaultDatadogSetup.Config()
+	defaultDatadogSetup.Config = datadog.NewConfiguration()
+	defaultDatadogSetup.Client = datadog.NewAPIClient(defaultDatadogSetup.Config)
+}
+
 func joinConfig(base []func() (Config, error), add []Config) (conf []Config, err error) {
 	nbase := len(base)
 	conf = make([]Config, nbase+len(add))


### PR DESCRIPTION
Logs methods called by phylum, with method param to subdivide them. View results [here](https://app.datadoghq.com/metric/explorer?from_ts=1653677111706&to_ts=1653678911706&live=false&tile_size=m&exp_agg=sum&exp_row_type=metric&exp_metric=clientmethod.call&exp_group=method)

Requires `./compose/.env` which defines
```sh
DD_API_KEY=<api_key_value>
DD_APP_KEY=<app_key_value>
DD_SITE="datadoghq.com"
```
Using values from https://app.datadoghq.com/organization-settings/api-keys / https://app.datadoghq.com/organization-settings/application-keys