### PR TITLE
upgrade docker compose to v2 to handle removal of support of v1

### DIFF
--- a/blockchain_compose.py
+++ b/blockchain_compose.py
@@ -145,7 +145,8 @@ class compose(object):
         prefix = []
         if sudo:
             prefix.extend(['sudo', '-E'])
-        prefix.append('docker-compose')
+        prefix.append('docker')
+        prefix.append('compose')
         prefix.extend(['-f', self._docker_compose_file()])
         return prefix
 


### PR DESCRIPTION
As per discussion here: https://github.com/orgs/community/discussions/116610#discussioncomment-10239694

Ubuntu have removed Docker Compose v1 support. This PR moves Sandbox to use v2 command syntax