### PR TITLE
Update fabric-network-builder to v0.0.4

### DIFF
--- a/common.config.mk
+++ b/common.config.mk
@@ -27,7 +27,7 @@ SHIROCLIENT_VERSION=${SUBSTRATE_VERSION}
 CONNECTORHUB_VERSION=${SUBSTRATE_VERSION}
 SHIROTESTER_VERSION=${SUBSTRATE_VERSION}
 # https://github.com/luthersystems/fabric-network-builder
-NETWORK_BUILDER_VERSION=v0.0.2
+NETWORK_BUILDER_VERSION=v0.0.4
 MARTIN_VERSION=v0.1.0
 
 # A golang module proxy server can greatly help speed up docker builds but the


### PR DESCRIPTION
## Summary
- Bump `NETWORK_BUILDER_VERSION` from `v0.0.2` to `v0.0.4` to fix local network `fabric/ make up`

## Test plan
- [x] Verified `fabric/ make up` works with the updated version locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)